### PR TITLE
set bids to zero when superscoring

### DIFF
--- a/src/interpreter/superscore.ts
+++ b/src/interpreter/superscore.ts
@@ -104,6 +104,8 @@ export default (interpreter: Interpreter): SciOlyFF => {
     (interpreter.tournament.nOffset as number) +
     ((interpreter.tournament.teams?.length as number) - teamNumbers.size);
 
+  tournamentRep["bids"] = 0;
+  
   return {
     superscore: true,
 


### PR DESCRIPTION
mentioned in discord: superscore doesn't actually *need* to have bids since it's a hypothetical with no implication of moving on to the next competition -- this may eliminate confusion when looking at superscored data